### PR TITLE
set imageType in VMWare_VCloud_SDK_Vdc::uploadMedia

### DIFF
--- a/library/VMware/VCloud/VCloud.php
+++ b/library/VMware/VCloud/VCloud.php
@@ -604,6 +604,7 @@ $vdcStorageProfileRef, $catalogRef)
      */
     private function uploadMedia($filename, $imageType, $mediaType)
     {
+        $mediaType->set_imageType($imageType);
         $mediaUpInfo = $this->sendUploadMediaRequest($mediaType);
         $url = $this->getMediaUploadInfo($mediaUpInfo);
         $durl =  $mediaUpInfo->get_href();


### PR DESCRIPTION
`VMware_VCloud_SDK_Vdc::uploadIsoMedia` and `VMware_VCloud_SDK_Vdc::uploadFloppyMedia` both delegate to the private method `VMware_VCloud_SDK_Vdc::uploadMedia`. However `VMware_VCloud_SDK_Vdc::uploadMedia` never makes use of the defined `$imageType` variable. 
